### PR TITLE
ETH transfert and variables checklist

### DIFF
--- a/LPT-bond-transfer.py
+++ b/LPT-bond-transfer.py
@@ -8,6 +8,7 @@ LPT_THRESHOLD = 100
 ETH_THRESHOLD = 0.1 # in ETH
 DELEGATOR_PRIVATE_KEY = 'InsertDelegatorPrivateKey'
 DELEGATOR_PUBLIC_KEY = 'InsertDelegatorWalletAddress'
+RECEIVER_PUBLIC_KEY = 'WalletThatWillReceiveAddress'
 ETH_RECEIVER_PUBLIC_KEY = 'ETHWalletThatWillReceiveAddress'
 LPT_RECEIVER_PUBLIC_KEY = 'LPTWalletThatWillReceiveAddress'
 L2_RPC_PROVIDER = 'https://arb1.arbitrum.io/rpc'
@@ -22,6 +23,16 @@ ROUNDS_CONTRACT_ADDR = '0xdd6f56DcC28D3F5f27084381fE8Df634985cc39f'
 @brief Returns a JSON object of ABI data
 @param path: absolute/relative path to an ABI file
 """
+def display_global_config():
+    print("Global Configuration:")
+    print("{:<25} {:<25}".format("Variable", "Value"))
+    print("-" * 50)
+    for key, value in globals().items():
+        if key == "DELEGATOR_PRIVATE_KEY":
+            continue
+        if key.isupper():
+            print("{:<25} {:<25}".format(key, value))
+
 def getABI(path):
     try:
         with open(path) as f:
@@ -160,6 +171,8 @@ def eth_transfer_loop():
         doTransferETH(w3, parsed_delegator_wallet, parsed_eth_destination_wallet)
 
 if __name__ == "__main__":
+    display_global_config()
+
     # convert configured wallets to usable versions
     parsed_delegator_wallet = getChecksumAddr(DELEGATOR_PUBLIC_KEY)
     parsed_eth_destination_wallet = getChecksumAddr(ETH_RECEIVER_PUBLIC_KEY)

--- a/LPT-bond-transfer.py
+++ b/LPT-bond-transfer.py
@@ -8,7 +8,6 @@ LPT_THRESHOLD = 100
 ETH_THRESHOLD = 0.1 # in ETH
 DELEGATOR_PRIVATE_KEY = 'InsertDelegatorPrivateKey'
 DELEGATOR_PUBLIC_KEY = 'InsertDelegatorWalletAddress'
-RECEIVER_PUBLIC_KEY = 'WalletThatWillReceiveAddress'
 ETH_RECEIVER_PUBLIC_KEY = 'ETHWalletThatWillReceiveAddress'
 LPT_RECEIVER_PUBLIC_KEY = 'LPTWalletThatWillReceiveAddress'
 L2_RPC_PROVIDER = 'https://arb1.arbitrum.io/rpc'

--- a/LPT-bond-transfer.py
+++ b/LPT-bond-transfer.py
@@ -166,11 +166,15 @@ if __name__ == "__main__":
     bonding_contract = w3.eth.contract(address=BONDING_CONTRACT_ADDR, abi=bondingABI)
     rounds_contract = w3.eth.contract(address=ROUNDS_CONTRACT_ADDR, abi=roundsABI)
 
-    # main loop
+    # main loop for LPT transfer
     while True:
         print("Initiating new round for delegator {0}".format(DELEGATOR_PUBLIC_KEY))
         waitForLPTStake(bonding_contract, parsed_delegator_wallet)
-        waitForETHBalance(w3, parsed_delegator_wallet)
         waitForLock(rounds_contract)
         doTransferLPT(bonding_contract, parsed_delegator_wallet, parsed_lpt_destination_wallet)
+
+    # main loop for ETH transfer
+    while True:
+        print("Initiating new round for delegator {0}".format(DELEGATOR_PUBLIC_KEY))
+        waitForETHBalance(w3, parsed_delegator_wallet)
         doTransferETH(w3, parsed_delegator_wallet, parsed_eth_destination_wallet)

--- a/LPT-bond-transfer.py
+++ b/LPT-bond-transfer.py
@@ -4,7 +4,7 @@ import time
 import threading
 
 # global config
-LPT_THRESHOLD = 100
+LPT_THRESHOLD = 3
 ETH_THRESHOLD = 0.1 # in ETH
 DELEGATOR_PRIVATE_KEY = 'InsertDelegatorPrivateKey'
 DELEGATOR_PUBLIC_KEY = 'InsertDelegatorWalletAddress'

--- a/LPT-bond-transfer.py
+++ b/LPT-bond-transfer.py
@@ -7,7 +7,6 @@ LPT_THRESHOLD = 100
 ETH_THRESHOLD = 0.1 # in ETH
 DELEGATOR_PRIVATE_KEY = 'InsertDelegatorPrivateKey'
 DELEGATOR_PUBLIC_KEY = 'InsertDelegatorWalletAddress'
-RECEIVER_PUBLIC_KEY = 'WalletThatWillReceiveAddress'
 ETH_RECEIVER_PUBLIC_KEY = 'ETHWalletThatWillReceiveAddress'
 LPT_RECEIVER_PUBLIC_KEY = 'LPTWalletThatWillReceiveAddress'
 L2_RPC_PROVIDER = 'https://arb1.arbitrum.io/rpc'

--- a/LPT-bond-transfer.py
+++ b/LPT-bond-transfer.py
@@ -3,11 +3,13 @@ import json
 import time
 
 # global config
-LPT_THRESHOLD = 3
+LPT_THRESHOLD = 100
 ETH_THRESHOLD = 0.1 # in ETH
 DELEGATOR_PRIVATE_KEY = 'InsertDelegatorPrivateKey'
 DELEGATOR_PUBLIC_KEY = 'InsertDelegatorWalletAddress'
 RECEIVER_PUBLIC_KEY = 'WalletThatWillReceiveAddress'
+ETH_RECEIVER_PUBLIC_KEY = 'ETHWalletThatWillReceiveAddress'
+LPT_RECEIVER_PUBLIC_KEY = 'LPTWalletThatWillReceiveAddress'
 L2_RPC_PROVIDER = 'https://arb1.arbitrum.io/rpc'
 
 # global constants
@@ -92,7 +94,7 @@ def waitForLock(rounds_contract):
 @param parsed_delegator_wallet: checksum public key of the delegator which wants to transfer stake
 @param parsed_destination_wallet: checksum address of the destination wallet
 """
-def doTransferLPT(bonding_contract, parsed_delegator_wallet, parsed_destination_wallet):
+def doTransferLPT(bonding_contract, parsed_delegator_wallet, parsed_lpt_destination_wallet):
     delegator_info = bonding_contract.functions.getDelegator(parsed_delegator_wallet).call()
     staked_lpt = web3.Web3.fromWei(delegator_info[0], 'ether')
     pending_lpt = bonding_contract.functions.pendingStake(parsed_delegator_wallet, 99999).call()
@@ -148,7 +150,8 @@ def doTransferETH(w3, parsed_delegator_wallet, parsed_destination_wallet):
 if __name__ == "__main__":
     # convert configured wallets to usable versions
     parsed_delegator_wallet = getChecksumAddr(DELEGATOR_PUBLIC_KEY)
-    parsed_destination_wallet = getChecksumAddr(RECEIVER_PUBLIC_KEY)
+    parsed_eth_destination_wallet = getChecksumAddr(ETH_RECEIVER_PUBLIC_KEY)
+    parsed_lpt_destination_wallet = getChecksumAddr(LPT_RECEIVER_PUBLIC_KEY)
 
     # open ABI files
     bondingABI = getABI("./BondingManagerTarget.json")
@@ -169,5 +172,5 @@ if __name__ == "__main__":
         waitForLPTStake(bonding_contract, parsed_delegator_wallet)
         waitForETHBalance(w3, parsed_delegator_wallet)
         waitForLock(rounds_contract)
-        doTransferLPT(bonding_contract, parsed_delegator_wallet, parsed_destination_wallet)
-        doTransferETH(w3, parsed_delegator_wallet, parsed_destination_wallet)
+        doTransferLPT(bonding_contract, parsed_delegator_wallet, parsed_lpt_destination_wallet)
+        doTransferETH(w3, parsed_delegator_wallet, parsed_eth_destination_wallet)

--- a/LPT-bond-transfer.py
+++ b/LPT-bond-transfer.py
@@ -128,7 +128,7 @@ def doTransferLPT(bonding_contract, parsed_delegator_wallet, parsed_lpt_destinat
 def doTransferETH(w3, parsed_delegator_wallet, parsed_destination_wallet):
     eth_balance = w3.eth.get_balance(parsed_delegator_wallet)
     transfer_amount = eth_balance - web3.Web3.toWei(0.01, 'ether') # leave 0.01 ETH as gas fee
-   ("Should transfer {0} ETH".format(web3.Web3.fromWei(transfer_amount, 'ether')))
+    print("Should transfer {0} ETH".format(web3.Web3.fromWei(transfer_amount, 'ether')))
     # Build transaction info
     tx = {
         'to': parsed_destination_wallet,

--- a/README.md
+++ b/README.md
@@ -2,12 +2,16 @@
 ```gh repo clone Pon-node/Lpt-bond-transfer```
 Modify ```nano /Lpt-bond-transfer/LPT-bond-Transfer.py``` to set LPT_treshold, insert wallet addresses,privates keys and you can change RPC provider if you want to
 
-LPT_THRESHOLD = 3
+LPT_THRESHOLD = 3 (Keeping 1 LPT)
+ETH_THRESHOLD = 0.1 (keeping 0.01 ETH for fee)
+
 DELEGATOR_PRIVATE_KEY = 'InsertDelegatorPrivateKey'
 
 DELEGATOR_PUBLIC_KEY = 'InsertDelegatorWalletAddress'
 
-RECEIVER_PUBLIC_KEY = 'WalletThatWillReveiveBondAddress'
+ETH_RECEIVER_PUBLIC_KEY = 'ETHWalletThatWillReceiveAddress'
+
+LPT_RECEIVER_PUBLIC_KEY = 'LPTWalletThatWillReceiveAddress'
 
 L2_RPC_PROVIDER = 'https://arb1.arbitrum.io/rpc'```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Lpt-bond-transfer
+﻿# Lpt-bond-and-ETH-transfer
 ```gh repo clone Pon-node/Lpt-bond-transfer```
 Modify ```nano /Lpt-bond-transfer/LPT-bond-Transfer.py``` to set LPT_treshold, insert wallet addresses,privates keys and you can change RPC provider if you want to
 


### PR DESCRIPTION
Add the transfer of ETH from the node when a certain threshold is reached (for example 0.1 ETH) and leave 0.01 ETH for fees.
The destination wallet for ETH can be different from the one for LPT.


List the different variables (except for the private address) when executing the script.